### PR TITLE
Add CI

### DIFF
--- a/.github/workflows/pagerduty-xbar.yaml
+++ b/.github/workflows/pagerduty-xbar.yaml
@@ -39,3 +39,6 @@ jobs:
           executable-name: example
           changes-file: ""
           working-directory: ./pagerduty-xbar
+          extra-files: |
+            xbar_pagerduty.sh
+            xbar_pagerduty_plugin.sh

--- a/.github/workflows/pagerduty-xbar.yaml
+++ b/.github/workflows/pagerduty-xbar.yaml
@@ -1,0 +1,41 @@
+name: PagerDuty xbar
+on:
+  push:
+    branches: [main]
+    tags: [v*]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.platform.runs-on }}
+    strategy:
+      # Using matrix with just one platform because there are other tools compatible
+      # with the xbar API and it's going to be easier to add them in the future.
+      matrix:
+        platform:
+          - os-name: macOS-aarch64
+            runs-on: macOS-latest
+            target: aarch64-apple-darwin
+            
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build binary
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: "--locked --release"
+          working-directory: ./pagerduty-xbar
+          strip: true
+      - name: Test - ${{ matrix.platform.os-name }}
+        uses: houseabsolute/actions-rust-cross@v1
+        with:
+          command: test
+          target: ${{ matrix.platform.target }}
+          working-directory: ./pagerduty-xbar
+      - name: Release - ${{ matrix.platform.os-name }}
+        uses: houseabsolute/actions-rust-release@v0
+        if: startsWith(github.ref, 'refs/tags/v')
+        with:
+          target: ${{ matrix.platform.target }}
+          executable-name: example
+          changes-file: ""
+          working-directory: ./pagerduty-xbar

--- a/.github/workflows/pagerduty-xbar.yaml
+++ b/.github/workflows/pagerduty-xbar.yaml
@@ -1,7 +1,6 @@
 name: PagerDuty xbar
 on:
   push:
-    branches: [main]
     tags: [v*]
 
 jobs:

--- a/.github/workflows/pagerduty-xbar.yaml
+++ b/.github/workflows/pagerduty-xbar.yaml
@@ -1,6 +1,7 @@
 name: PagerDuty xbar
 on:
   push:
+    branches: ["*"]
     tags: [v*]
 
 jobs:

--- a/pagerduty-xbar/README.md
+++ b/pagerduty-xbar/README.md
@@ -22,7 +22,7 @@ For **development** (when run from within the git repository) the script uses
 
 ## Installation
 
-To install from source:
+### From source
 
 ```sh
 $ git clone git@github.com:jakub-m/toolbox-rs.git
@@ -30,7 +30,10 @@ $ cargo build --release
 $ ln -s $(realpath xbar_pagerduty_plugin.sh) "$HOME/Library/Application Support/xbar/plugins/pagerduty.5m.sh"
 ```
 
+### Releases
 If you don't have the Rust toolchain installed you can also go to [releases][releases] and grab the prebuilt binary. Then you need to extract the files, place them in one directory and execute:
+
+[releases]: https://github.com/jakub-m/toolbox-rs/releases
 
 ```sh
 ln -s $(realpath xbar_pagerduty_plugin.sh) "$HOME/Library/Application Support/xbar/plugins/pagerduty.5m.sh"
@@ -38,4 +41,4 @@ ln -s $(realpath xbar_pagerduty_plugin.sh) "$HOME/Library/Application Support/xb
 
 You can also place `xbar_pagerduty_plugin.sh` in the plugins folder manually, just make sure to change the path pointing to `xbar_pagerduty.sh`.
 
-[releases]: https://github.com/jakub-m/toolbox-rs/releases
+NOTE: macOS will most likely complain about untrusted binaries. To fix this go to "Privacy & Security" in System Settings and look for a warning in the "Security" section where you can choose to trust the program.

--- a/pagerduty-xbar/README.md
+++ b/pagerduty-xbar/README.md
@@ -22,8 +22,20 @@ For **development** (when run from within the git repository) the script uses
 
 ## Installation
 
+To install from source:
+
 ```sh
 $ git clone git@github.com:jakub-m/toolbox-rs.git
 $ cargo build --release
 $ ln -s $(realpath xbar_pagerduty_plugin.sh) "$HOME/Library/Application Support/xbar/plugins/pagerduty.5m.sh"
 ```
+
+If you don't have the Rust toolchain installed you can also go to [releases][releases] and grab the prebuilt binary. Then you need to extract the files, place them in one directory and execute:
+
+```sh
+ln -s $(realpath xbar_pagerduty_plugin.sh) "$HOME/Library/Application Support/xbar/plugins/pagerduty.5m.sh"
+```
+
+You can also place `xbar_pagerduty_plugin.sh` in the plugins folder manually, just make sure to change the path pointing to `xbar_pagerduty.sh`.
+
+[releases]: https://github.com/jakub-m/toolbox-rs/releases


### PR DESCRIPTION
I tested this in a private repo and I think it should work but I couldn't get it to trigger on my fork. The basic idea is to build and test on any push but it will create GH releases with built files on tags beginning with `v*`. It's going to be a little awkward if there are more tools in this repo but I think that can be handled later if there's a need for builds for that too.

I hope this won't require extra tweaking after merging but you will need to enable write access for the Github token under Settings > Actions > General.
<img width="783" alt="image" src="https://github.com/user-attachments/assets/df88ff11-7618-44bd-8b39-dd10caa2e515" />
